### PR TITLE
fix: prevent text clipping in community section gradient text

### DIFF
--- a/src/components/layout/sections/community.tsx
+++ b/src/components/layout/sections/community.tsx
@@ -19,7 +19,7 @@ export const CommunitySection = () => {
                             <Github className="mb-4 h-16 w-16" />
                             <CardTitle className="flex flex-col items-center text-center font-bold text-4xl md:text-5xl">
                                 <div className="whitespace-nowrap">Contribute to this</div>
-                                <span className="bg-gradient-to-r from-[#da5319] to-primary bg-clip-text text-transparent">
+                                <span className="bg-gradient-to-r from-[#da5319] to-primary bg-clip-text text-transparent py-1">
                                     Project
                                 </span>
                             </CardTitle>


### PR DESCRIPTION
## Fix text clipping in community section

### Problem
The gradient text "Project" in the community section was experiencing text clipping issues where the bottom part of descending letters (like the letter "j") was being cut off due to insufficient container height.

### Solution
Added `py-1` (vertical padding) to the gradient text span to provide adequate space for descenders, ensuring the complete text is visible without clipping.

### Before
<img width="1652" height="1104" alt="image" src="https://github.com/user-attachments/assets/01d86533-2d20-4d14-b563-dfde9d841b3e" />

### After
<img width="1582" height="984" alt="image" src="https://github.com/user-attachments/assets/5a173156-bfa5-45b5-9732-463605b95715" />
